### PR TITLE
Parameter name ‘scan’ —> ‘acquisition’

### DIFF
--- a/OLApproachSupport/OLSessionLogs/OLSessionLog.m
+++ b/OLApproachSupport/OLSessionLogs/OLSessionLog.m
@@ -114,9 +114,9 @@ switch theStep
         fileID = fopen(protocolParams.fullFileName,'a');
         switch p.StartEnd
             case 'start'
-                fprintf(fileID,'\n%s%s: %s -- Scan # %s started @ %s.\n',p.PrePost,theStep,protocolParams.protocolOutputName, num2str(protocolParams.scanNumber), datestr(now,'HH:MM:SS'));
+                fprintf(fileID,'\n%s%s: %s -- acquisition # %s started @ %s.\n',p.PrePost,theStep,protocolParams.protocolOutputName, num2str(protocolParams.acquisitionNumber), datestr(now,'HH:MM:SS'));
             case 'end'
-                fprintf(fileID,'%s%s: %s -- Scan # %s finished @ %s.\n',p.PrePost,theStep,protocolParams.protocolOutputName, num2str(protocolParams.scanNumber), datestr(now,'HH:MM:SS'));
+                fprintf(fileID,'%s%s: %s -- acquisition # %s finished @ %s.\n',p.PrePost,theStep,protocolParams.protocolOutputName, num2str(protocolParams.acquisitionNumber), datestr(now,'HH:MM:SS'));
         end
         
     otherwise


### PR DESCRIPTION
Propose that we use the term "acquisition" to refer to a discrete period of execution of trials of an experiment. This replaces the term "scan" and is more general purpose, easily applying to EMG, fMRI, psychophysics, etc.