### PR TITLE
Hotfix stateTrackingData empty struct

### DIFF
--- a/OLLibrary/OLCorrectPrimaryValues.m
+++ b/OLLibrary/OLCorrectPrimaryValues.m
@@ -97,7 +97,7 @@ iterativeSearch = parser.Results.iterativeSearch;
 measureStateTrackingSPDs = parser.Results.measureStateTrackingSPDs;
 
 %% Measure state-tracking SPDs
-stateTrackingData = struct();
+stateTrackingData = struct([]);
 if (measureStateTrackingSPDs)
     % Generate temporary calibration struct with stateTracking info
     tmpCal = calibration;

--- a/OLLibrary/OLMeasurePrimaryValues.m
+++ b/OLLibrary/OLMeasurePrimaryValues.m
@@ -64,7 +64,7 @@ measureStateTrackingSPDs = parser.Results.measureStateTrackingSPDs;
 temperatureProbe = parser.Results.temperatureProbe;
 
 %% Measure state tracking SPDs
-stateTrackingData = struct();
+stateTrackingData = struct([]);
 if (~isempty(radiometer)) && (measureStateTrackingSPDs)
     % Generate temporary calibration struct with stateTracking info
     tmpCal = calibration;

--- a/OLLibrary/OLMeasurePrimaryValues.m
+++ b/OLLibrary/OLMeasurePrimaryValues.m
@@ -64,7 +64,6 @@ measureStateTrackingSPDs = parser.Results.measureStateTrackingSPDs;
 temperatureProbe = parser.Results.temperatureProbe;
 
 %% Measure state tracking SPDs
-stateTrackingData = struct([]);
 if (~isempty(radiometer)) && (measureStateTrackingSPDs)
     % Generate temporary calibration struct with stateTracking info
     tmpCal = calibration;
@@ -77,6 +76,7 @@ if (~isempty(radiometer)) && (measureStateTrackingSPDs)
         'standAlone', true);
 
     % Save the data
+    stateTrackingData = struct();
     stateTrackingData.spectralShift.spd    = calMeasOnly.raw.spectralShiftsMeas.measSpd;
     stateTrackingData.spectralShift.t      = calMeasOnly.raw.spectralShiftsMeas.t;
     stateTrackingData.powerFluctuation.spd = calMeasOnly.raw.powerFluctuationMeas.measSpd;
@@ -84,6 +84,8 @@ if (~isempty(radiometer)) && (measureStateTrackingSPDs)
 
     % Remove tmpCal
     clear('tmpCal')
+else
+    stateTrackingData = struct([]);
 end
     
 %% Convert primary values to starts and stops

--- a/OLPrograms/@OLCalibrator/TakeStateMeasurements.m
+++ b/OLPrograms/@OLCalibrator/TakeStateMeasurements.m
@@ -67,8 +67,8 @@ function [cal, calMeasOnly] = TakeStateMeasurements(cal0, ol, od, spectroRadiome
             cal.raw.temperature.value(cal.describe.stateTracking.stateMeasurementIndex,:) = temperatureValue;
             cal.raw.temperature.t(cal.describe.stateTracking.stateMeasurementIndex,:) = measTemp.pr650.time(1);
         end
+        fprintf('Done\n');
     end
-    fprintf('Done\n');
 
     if (~isempty(calProgressionTemporaryFileName))
         % make spdData struct


### PR DESCRIPTION
Tracking state data in several routines produces a struct with state tracking data. However, when not actually tracking state data (simulated, or flag set to `false`), this code returns an 1x1 struct array, the result of `struct()`.

The problem with this behavior is that `isEmpty( struct() )` returns false, since it is an 1x1 struct array, even if it has no fields. Instead, we want to pass back the empty struct array `struct([])`. This hotfix takes care of that.