### PR TITLE
Hotfix: `OLDirection.SPDdifferentialDesired` would not scale correctly

### DIFF
--- a/OLApproachSupport/@OLDirection_bipolar/OLDirection_bipolar.m
+++ b/OLApproachSupport/@OLDirection_bipolar/OLDirection_bipolar.m
@@ -91,6 +91,7 @@ classdef OLDirection_bipolar < OLDirection
                 % Create new direction
                 newDescribe = struct('createdFrom',struct('a',direction,'b',s,'operator','.*'),'correction',[],'validation',[]);
                 newDirection = OLDirection_bipolar(s*direction.differentialPositive,s*direction.differentialNegative,direction.calibration,newDescribe);
+                newDirection.SPDdifferentialDesired = s*direction.SPDdifferentialDesired;
                 out = [out newDirection];
             end
         end

--- a/OLApproachSupport/@OLDirection_unipolar/OLDirection_unipolar.m
+++ b/OLApproachSupport/@OLDirection_unipolar/OLDirection_unipolar.m
@@ -89,6 +89,7 @@ classdef OLDirection_unipolar < OLDirection
                 % Create new direction
                 newDescribe = struct('createdFrom',struct('a',direction,'b',s,'operator','.*'),'correction',[],'validation',[]);
                 newDirection = OLDirection_unipolar(s*direction.differentialPrimaryValues,direction.calibration,newDescribe);
+                newDirection.SPDdifferentialDesired = s*direction.SPDdifferentialDesired;
                 out = [out newDirection];
             end
         end


### PR DESCRIPTION
Multiplying a direction by a scalar would correctly scale the differential primary values, but then calculate the SPD differentialDesired from the new primary values. In the case of a corrected direction, where the primary values and SPD are no longer a linear transformation, this would yield an incorrect `SPDdifferentialDesired`.
This fix overwrites the `SPDdifferentialDesired` of the new, scaled, direction, with a scaled version of the original SPD.