### PR TITLE
Refactored gamut checking, truncation

### DIFF
--- a/OLLibrary/OLCheckPrimaryGamut.m
+++ b/OLLibrary/OLCheckPrimaryGamut.m
@@ -226,8 +226,7 @@ if (p.Results.checkPrimaryOutOfRange && ~inGamut)
     error('At least one primary values is out of gamut');
 else
     % In this case, force primaries to be within gamut
-    primary(primary > gamutMinMax(2)) = gamutMinMax(2);
-    primary(primary < gamutMinMax(1)) = gamutMinMax(1);
+    primary = OLTruncatePrimaryValues(primary,gamutMinMax);
 end
 
 end

--- a/OLLibrary/OLCheckPrimaryGamut.m
+++ b/OLLibrary/OLCheckPrimaryGamut.m
@@ -90,7 +90,8 @@ function [primary, inGamut, gamutMargin] = OLCheckPrimaryGamut(primary,varargin)
 
 % History:
 %   04/12/18  dhb  Wrote it.
-%   12/19/18  jv   Extracted OLGamutMargins
+%   12/19/18  jv   Extracted OLGamutMargins, OLCheckPrimaryValues,
+%                  OLTruncateGamutTolerance
 
 % Examples:
 
@@ -210,11 +211,8 @@ end
 % Headroom is effectively just shrinking the gamut
 gamutMinMax = gamutMinMax + p.Results.primaryHeadroom * [1 -1];
 
-%% Check that primaries are within gamut to tolerance.
-% Truncate and call it good if so, throw error conditionally on checking if
-% not.
-primary(primary < gamutMinMax(1) & primary > gamutMinMax(1) - p.Results.primaryTolerance) = gamutMinMax(1);
-primary(primary > gamutMinMax(2) & primary < gamutMinMax(2) + p.Results.primaryTolerance) = gamutMinMax(2);
+%% Truncate primaries by gamut tolerance
+primary = OLTruncateGamutTolerance(primary,gamutMinMax,p.Results.primaryTolerance);
 
 %% Get gamut margins
 gamutMargins = OLGamutMargins(primary(:), gamutMinMax);

--- a/OLLibrary/OLCheckPrimaryGamut.m
+++ b/OLLibrary/OLCheckPrimaryGamut.m
@@ -44,7 +44,7 @@ function [primary, inGamut, gamutMargin] = OLCheckPrimaryGamut(primary,varargin)
 %                               be checked
 %
 % Outputs:
-%    primary                  - Numeric matrix (NxM) of primary values, 
+%    primary                  - Numeric matrix (NxM) of primary values,
 %                               after truncation and check
 %    inGamut                  - Boolean scalar. True if passed primaries
 %                               were within primaryTolerance of being in
@@ -58,7 +58,7 @@ function [primary, inGamut, gamutMargin] = OLCheckPrimaryGamut(primary,varargin)
 %                               in gamut, amount negative tells you
 %                               magnitude of margin. Otherwise this is the
 %                               magnitude of the largest deviation
-% 
+%
 % Optional keyword arguments:
 %    'differentialMode'       - Boolean scalar. If true, allowable gamut
 %                               starts at [-1,1] not at [0,1], and then is
@@ -199,9 +199,6 @@ p.addParameter('primaryTolerance', 1e-6, @isscalar);
 p.addParameter('checkPrimaryOutOfRange', true, @islogical);
 p.parse(varargin{:});
 
-%% Initialize
-inGamut = true;
-
 %% Set up gamut / Handle differential mode
 if (p.Results.differentialMode)
     lowerGamut = -1;
@@ -221,16 +218,16 @@ primary(primary > upperGamut - p.Results.primaryHeadroom & primary < upperGamut 
 gamutMargins = OLGamutMargins(primary(:),[lowerGamut+p.Results.primaryHeadroom,upperGamut-p.Results.primaryHeadroom]);
 gamutMargin = max(-gamutMargins);
 
-%%
-if ( (any(primary(:) > upperGamut - p.Results.primaryHeadroom) || any(primary(:) < lowerGamut + p.Results.primaryHeadroom) ))
-    if (p.Results.checkPrimaryOutOfRange)  
-        error('At one least primary value is out of gamut');
-    else
-        % In this case, force primaries to be within gamut
-        inGamut = false;
-        primary(primary > upperGamut - p.Results.primaryHeadroom) = upperGamut - p.Results.primaryHeadroom;
-        primary(primary < lowerGamut + p.Results.primaryHeadroom) = lowerGamut + p.Results.primaryHeadroom;
-    end
+%% Check if in gamut, get margin
+inGamut = OLCheckPrimaryValues(primary, [lowerGamut+p.Results.primaryHeadroom,upperGamut-p.Results.primaryHeadroom]);
+
+%% Error if necessary
+if (p.Results.checkPrimaryOutOfRange && ~inGamut)
+    error('At least one primary values is out of gamut');
+else
+    % In this case, force primaries to be within gamut
+    primary(primary > upperGamut - p.Results.primaryHeadroom) = upperGamut - p.Results.primaryHeadroom;
+    primary(primary < lowerGamut + p.Results.primaryHeadroom) = lowerGamut + p.Results.primaryHeadroom;
 end
 
 end

--- a/OLLibrary/OLCheckPrimaryGamut.m
+++ b/OLLibrary/OLCheckPrimaryGamut.m
@@ -90,6 +90,7 @@ function [primary, inGamut, gamutMargin] = OLCheckPrimaryGamut(primary,varargin)
 
 % History:
 %   04/12/18  dhb  Wrote it.
+%   12/19/18  jv   Extracted OLGamutMargins
 
 % Examples:
 
@@ -200,9 +201,8 @@ p.parse(varargin{:});
 
 %% Initialize
 inGamut = true;
-gamutMargin = 0;
 
-%% Handle differential mode
+%% Set up gamut / Handle differential mode
 if (p.Results.differentialMode)
     lowerGamut = -1;
 else
@@ -217,11 +217,11 @@ upperGamut = 1;
 primary(primary < lowerGamut + p.Results.primaryHeadroom & primary > lowerGamut + p.Results.primaryHeadroom - p.Results.primaryTolerance) = lowerGamut + p.Results.primaryHeadroom;
 primary(primary > upperGamut - p.Results.primaryHeadroom & primary < upperGamut - p.Results.primaryHeadroom + p.Results.primaryTolerance) = upperGamut - p.Results.primaryHeadroom;
 
-% Compute gamut deviation as a positive number meaning deviation
-upperGamutMargin = max(primary(:) - (upperGamut-p.Results.primaryHeadroom));
-lowerGamutMargin = -(min(primary(:)) - (lowerGamut+p.Results.primaryHeadroom));
-gamutMargin = max([upperGamutMargin lowerGamutMargin]);
+%% Get gamut margins
+gamutMargins = OLGamutMargins(primary(:),[lowerGamut+p.Results.primaryHeadroom,upperGamut-p.Results.primaryHeadroom]);
+gamutMargin = max(-gamutMargins);
 
+%%
 if ( (any(primary(:) > upperGamut - p.Results.primaryHeadroom) || any(primary(:) < lowerGamut + p.Results.primaryHeadroom) ))
     if (p.Results.checkPrimaryOutOfRange)  
         error('At one least primary value is out of gamut');

--- a/OLLibrary/OLCheckPrimaryValues.m
+++ b/OLLibrary/OLCheckPrimaryValues.m
@@ -1,0 +1,71 @@
+function inGamut = OLCheckPrimaryValues(primaryValues,gamutMinMax)
+% Check whether primary values are within gamut
+%
+% Syntax:
+%   inGamut = OLCheckPrimaryValues(primaryValues, gamut)
+%   [inGamut, gamutMargins] = OLCheckPrimaryValues(...)
+%
+% Description:
+%    Compare given primary values to given gamut, and see whether primary
+%    values fall completely within gamut, i.e., is the lowest primary value
+%    greater than the bottom of the gamut, and the highest primary value
+%    lower than the top of the gamut.
+%
+% Inputs:
+%    primaryValues - Numeric matrix (NxM), of primary values to be 
+%                    truncated
+%    gamutMinMax   - Numeric 1x2 vector specifying [min, max] of 
+%                    gamut
+%
+% Outputs:
+%    inGamut       - Boolean scalar, are primary values within gamut
+%
+% Optional keyword arguments:
+%    None.
+%
+% Examples are provided in the source code.
+%
+% See also:
+%    OLCheckPrimaryGamut, OLGamutMargins
+
+% History:
+%    04/12/18  dhb  wrote OLCheckPrimaryGamut.
+%    12/19/18  jv   extracted OLGamutMargins from OLCheckPrimaryGamut and
+%                   wrote OLCheckPrimaryValues as wrapper (checks if all
+%                   margins are >= 0)
+
+% Examples:
+%{
+    %% .9 is in gamut = [0, 1]
+    primaryValues = .9;
+    gamut = [0 1];
+    inGamut = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(inGamut);
+%}
+%{
+    %% 1.1 is not in gamut = [0, 1]
+    primaryValues = 1.1;
+    gamut = [0 1];
+    inGamut = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(~inGamut);
+%}
+%{
+    %% -.9 is not in gamut = [0,1]
+    primaryValues = -.9;
+    gamut = [0 1];
+    inGamut = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(~inGamut);
+%}
+%{
+    %% -.9 is in gamut = [-1,1]
+    primaryValues = -.9;
+    gamut = [-1 1];
+    inGamut = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(inGamut);
+%}
+
+%%
+gamutMargins = OLGamutMargins(primaryValues,gamutMinMax); 
+    
+inGamut = all(gamutMargins >= 0);
+end

--- a/OLLibrary/OLGamutMargins.m
+++ b/OLLibrary/OLGamutMargins.m
@@ -1,0 +1,65 @@
+function gamutMargins = OLGamutMargins(primaryValues,gamutMinMax)
+% Calculate how much room/margin is left in gamut
+%
+% Syntax:
+%   gamutMargins = OLGamutMargins(primaryValues, gamut)
+%
+% Description:
+%    Compare given primary values to given gamut, and see what the gamut
+%    margin is, i.e., how much room between the lowest primary value and
+%    the bottom of the gamut, and the highest primary value and the top of
+%    the gamut. If primar values are outside of gamut, gamutMargins are
+%    negatively signed and indicate the overage.
+%
+% Inputs:
+%    primaryValues - Numeric matrix (NxM), of primary values to be 
+%                    truncated
+%    gamutMinMax   - Numeric 1x2 vector specifying [min, max] of 
+%                    gamut
+%
+% Outputs:
+%    gamutMargins  - 1x2 numeric, distance between min primary and gamut
+%                    min, and max primary and gamut max, respectively.
+%                    Positive margin indicates primary is within gamut,
+%                    negative margin indicates how far value is outside
+%                    gamut.
+%
+% Optional keyword arguments:
+%    None.
+%
+% Examples are provided in the source code.
+%
+% See also:
+%    OLCheckPrimaryGamut
+
+% History:
+%    04/12/18  dhb  wrote OLCheckPrimaryGamut.
+%    12/19/18  jv   extracted OLGamutMargins from OLCheckPrimaryGamut
+%{
+    %% [-.9] compared to gamut [-1, 1] has margins [.1, 1.9]
+    primaryValues = -.9;
+    gamut = [-1 1];
+    [~, gamutMargins] = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(all(round(gamutMargins,3) == [.1, 1.9]));
+%}
+%{
+    %% [-.9, .8] compared to gamut [-1, 1] has margins [.1, .2]
+    primaryValues = [-.9, .8];
+    gamut = [-1 1];
+    [~, gamutMargins] = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(all(round(gamutMargins,3) == [.1, .2]));
+%}
+%{
+    %% Adding a non min or max primary value does not affect margins
+    primaryValues = [-.9, .8, .5];
+    gamut = [-1 1];
+    [~, gamutMargins] = OLCheckPrimaryValues(primaryValues, gamut);
+    assert(all(round(gamutMargins,3) == [.1, .2]));
+%}
+
+%%
+gamut = sort(gamutMinMax); % ensure gamut = [min, max]
+
+primaryValuesMinMax = [min(primaryValues(:)) max(primaryValues(:))];
+gamutMargins = [primaryValuesMinMax(1) - gamut(1), gamut(2) - primaryValuesMinMax(2)]; 
+end

--- a/OLLibrary/OLTruncateGamutTolerance.m
+++ b/OLLibrary/OLTruncateGamutTolerance.m
@@ -1,0 +1,127 @@
+function truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues, gamutMinMax, primaryTolerance)
+% Truncate primary values towards gamut by no more than specified tolerance
+%
+% Syntax:
+%   truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues, gamut, tolerance)
+%
+% Description:
+%    Truncate primary values towards gamut limits, up to specified
+%    tolerance. Any primary values in gamut before truncation remain the
+%    same; any values out of gamut by up to tolerance are truncated to
+%    gamut; any values out of gamut by more than tolerance are truncated by
+%    tolerance, but remain out of gamut.
+%
+%    Generally, we use this function to get rid of small rounding errors.
+%
+% Inputs:
+%    primaryValues          - Numeric matrix (NxM), of primary values to be 
+%                             truncated
+%    gamutMinMax            - Numeric 1x2 vector specifying [min, max] of 
+%                             gamut
+%    primaryTolerance       - Numeric Scalar, maximum amount to truncate
+%
+% Outputs:
+%    truncatedPrimaryValues - Numeric matrix (NxM) of primary values, now 
+%                             truncated by no more than primaryTolerance.
+%                             Any primary values in gamut before truncation
+%                             remain the same; any values out of gamut by
+%                             up to tolerance are truncated to gamut; any
+%                             values out of gamut by more than tolerance
+%                             are truncated by tolerance, but remain out of
+%                             gamut.
+% 
+% Optional keyword arguments:
+%    None.
+%
+% Examples are provided in the source code.
+%
+% See also:
+%    OLTruncatePrimaryValues, OLCheckPrimaryValues, OLCheckPrimaryGamut
+
+% History:
+%    04/12/18  dhb  wrote OLCheckPrimaryGamut.
+%    12/19/18  jv   extracted from OLCheckPrimaryGamut
+
+% Examples:
+%{
+    %% Truncate value smaller than tolerance; truncates to gamut
+    primaryValues = 1+1e-6;
+    primaryTolerance = 1e-5;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(truncatedPrimaryValues == 1);
+%}
+%{
+    %% Truncate value smaller than tolerance; truncates to gamut
+    primaryValues = 0-1e-6;
+    primaryTolerance = 1e-5;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(truncatedPrimaryValues == 0);
+%}
+%{
+    %% Truncate value smaller than tolerance; truncates to gamut
+    primaryValues = -1-1e-6;
+    primaryTolerance = 1e-5;
+    gamut = [-1 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(truncatedPrimaryValues == -1);
+%}
+%{
+    %% Truncate value larger than tolerance; truncates by tolerance
+    primaryValues = 1+1e-4;
+    primaryTolerance = 1e-5;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(round(truncatedPrimaryValues,6) == 1+(1e-4)-(1e-5));
+%}
+%{
+    %% Truncate value larger than tolerance; truncates by tolerance
+    primaryValues = 0-1e-4;
+    primaryTolerance = 1e-5;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(round(truncatedPrimaryValues,6) == 0-(1e-4)+(1e-5));
+%}
+%{
+    %% Primary value initially in gamut remains unaffected
+    primaryValues = .5;
+    primaryTolerance = 1e-5;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(truncatedPrimaryValues == primaryValues)
+%}
+%{
+    %% Truncate both top and bottom, in and out of gamut:
+    primaryValues = [.9 1.04 1.1 .1 -.04 -.1];
+    primaryTolerance = .05;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryTolerance(primaryValues,...
+    gamut, primaryTolerance);
+    assert(all(round(truncatedPrimaryValues,7) == [.9 1 1.05 .1 0 -.05]));
+%}
+
+%% Sort gamutMinMax
+% ensure gamut = [min, max]
+gamutMinMax = sort(gamutMinMax);
+
+%% Truncate
+% Top of gamut
+primaryErrorTop = (max(primaryValues - gamutMinMax(2),0));
+truncatedErrorTop = (min(primaryErrorTop, primaryTolerance));
+primaryValues = primaryValues - truncatedErrorTop;
+
+% Bottom of gamut
+primaryErrorBottom = (min(primaryValues - gamutMinMax(1),0));
+truncatedErrorBottom = (max(primaryErrorBottom, -primaryTolerance));
+primaryValues = primaryValues - truncatedErrorBottom;
+
+%% Return
+truncatedPrimaryValues = primaryValues;
+end

--- a/OLLibrary/OLTruncatePrimaryValues.m
+++ b/OLLibrary/OLTruncatePrimaryValues.m
@@ -1,0 +1,94 @@
+function truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues,gamutMinMax)
+% Truncates primary values to be within specified gamut
+%
+% Syntax:
+%   truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut)
+%
+% Description:
+%    Truncate a matrix (or vector, scalar) of primary values to be within
+%    specified gamut; after truncation min(primaryValues) >= gamut(1), and
+%    max(primaryValues) <= gamut(2).
+%
+% Inputs:
+%    primaryValues          - Numeric matrix (NxM), of primary values to be 
+%                             truncated
+%    gamutMinMax            - Numeric 1x2 vector specifying [min, max] of 
+%                             gamut
+%
+% Outputs:
+%    truncatedPrimaryValues - Numeric matrix (NxM) of primary values, now 
+%                             truncated to be in gamut
+%
+% Optional keyword arguments:
+%    None.
+%
+% Examples are provided in the source code.
+%
+% See also:
+%    OLTruncatePrimaryTolerance, OLCheckPrimaryValues, OLCheckPrimaryGamut,
+%    OLPrimaryToSpd
+
+% History:
+%    04/12/18  dhb  wrote OLCheckPrimaryGamut.
+%    12/19/18  jv   extracted from OLCheckPrimaryGamut, as wrapper around
+%                   OLTruncatePrimaryTolerance (with tolerance = Inf)
+
+% Examples:
+%{
+    %% Truncate to gamut-max
+    primaryValues = 2;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+
+    % Check
+    assert(truncatedPrimaryValues == 1);
+%}
+%{
+    %% Truncate to gamut-min
+    primaryValues = -1;
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+
+    % Check
+    assert(truncatedPrimaryValues == 0);
+%}
+%{
+    %% Truncate to gamut = [0 1]
+    primaryValues = [-.5 0 .4 .8 1 1.6];
+    gamut = [0 1];
+    truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+
+    % Check
+    assert(all(truncatedPrimaryValues == [0 0 .4 .8 1 1]));
+%}
+%{
+    %% Truncate to gamut = [-1 1]
+    primaryValues = [-1 1];
+    gamut = [-1 1];
+    truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+
+    % Check
+    assert(all(truncatedPrimaryValues == primaryValues));
+%}
+%{
+    %% Gamut is auto-sorted
+    primaryValues = [-1 -1];
+    gamut = [0 -1];
+    truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+
+    % Check
+    assert(all(truncatedPrimaryValues == primaryValues));
+%}
+%{
+    %% Leave some 'headroom' on primaries:
+    primaryValues = [0 .8 1];
+    gamut = [0.005 .995];
+    truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+
+    % Check
+    assert(all(truncatedPrimaryValues == [.005 .8 .995]));    
+%}
+
+%%
+truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues, gamutMinMax, Inf);
+end

--- a/xTests/testOLCheckPrimaryGamut.m
+++ b/xTests/testOLCheckPrimaryGamut.m
@@ -1,0 +1,127 @@
+classdef testOLCheckPrimaryGamut < matlab.unittest.TestCase
+    %TESTOLCHECKPRIMARYGAMUT Summary of this class goes here
+    %   Detailed explanation goes here
+    
+    methods (Test)
+        % Test basic error throwing
+        function error(testCase)
+            verifyError(testCase, @() OLCheckPrimaryGamut(1.1),'')
+            verifyError(testCase, @() OLCheckPrimaryGamut(-.1),'')
+        end
+        function noError(testCase)
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(.8));
+        end
+        
+        % Test tolerance
+        function withinTolerance(testCase)
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(1+1e-8));
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(0-1e-8));
+        end
+        function outOfTolerance(testCase)
+            verifyError(testCase, @() OLCheckPrimaryGamut(1+1e-5),'');
+            verifyError(testCase, @() OLCheckPrimaryGamut(0-1e-5),'');
+        end
+        
+        % Test return arguments
+        function returnArgPrimary(testCase)
+            primary = OLCheckPrimaryGamut([.3 .6]);
+            verifyEqual(testCase,primary,[.3 .6]);
+        end
+        function returnArgInGamut(testCase)
+            [~,inGamut] = OLCheckPrimaryGamut([0 1]);
+            verifyTrue(testCase,inGamut);
+        end
+        function returnArgInGamutTolerance(testCase)
+            [~,inGamut] = OLCheckPrimaryGamut([0-1e-8 1+1e-8]);
+            verifyTrue(testCase,inGamut);
+        end
+        function gamutMarginTolerance(testCase)
+            [~, ~, gamutMargin] = OLCheckPrimaryGamut([0-1e-8, 1+1e-8]);
+            verifyEqual(testCase,gamutMargin,0,'AbsTol',1e-6);
+        end
+        function gamutMarginInGamut(testCase)
+            [~, ~, gamutMargin] = OLCheckPrimaryGamut([0.1, .8]);
+            verifyEqual(testCase,gamutMargin,-0.1,'AbsTol',1e-6);
+        end
+        
+        % Test truncation
+        function truncationWithinTolerance(testCase)
+            verifyEqual(testCase,OLCheckPrimaryGamut(1+1e-8),1,'AbsTol',1e-6);
+            verifyEqual(testCase,OLCheckPrimaryGamut(0-1e-8),0,'AbsTol',1e-6);
+            verifyEqual(testCase,OLCheckPrimaryGamut([0-1e-8, 1+1e-8]),[0 1],'AbsTol',1e-6);
+        end
+        
+        % Test differentialMode
+        function differentialModeNoError(testCase)
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(-.8,'differentialMode',true));
+        end
+        function differentialModeError(testCase)
+            verifyError(testCase, @() OLCheckPrimaryGamut(1.1,'differentialMode',true),'')
+            verifyError(testCase, @() OLCheckPrimaryGamut(-1.1,'differentialMode',true),'')
+        end
+        function differentialModeWithinTolerance(testCase)
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(-1-1e-8,'differentialMode',true));
+        end
+        function differentialModeTruncation(testCase)
+            verifyEqual(testCase,OLCheckPrimaryGamut([-1-1e-8, 1+1e-8],'differentialMode',true),[-1 1],'AbsTol',1e-8);
+        end
+        function differentialModeInGamut(testCase)
+            [~,inGamut] = OLCheckPrimaryGamut([-1 1],'differentialMode', true);
+            verifyTrue(testCase,inGamut);
+        end
+        function differentialModeGamutMargin(testCase)
+            [~, ~, gamutMargin] = OLCheckPrimaryGamut([0.1, .8],'differentialMode',true);
+            verifyEqual(testCase,gamutMargin,-0.2,'AbsTol',1e-6);
+        end
+        
+        % Test argument primaryTolerance
+        function adjustedTolerance(testCase)
+            verifyError(testCase, @() OLCheckPrimaryGamut(0-1e-4),'');
+            verifyError(testCase, @() OLCheckPrimaryGamut(1+1e-4),'');
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(1+1e-4,'primaryTolerance',1e-3));
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(0-1e-4,'primaryTolerance',1e-3));
+        end
+        function truncationWithinAdjustedTolerance(testCase)
+            verifyEqual(testCase,OLCheckPrimaryGamut(1+1e-4,'primaryTolerance',1e-3),1);
+            verifyEqual(testCase,OLCheckPrimaryGamut(0-1e-4,'primaryTolerance',1e-3),0);
+            verifyEqual(testCase,OLCheckPrimaryGamut([0-1e-4, 1+1e-4],'primaryTolerance',1e-3),[0 1]);
+        end
+        function gamutMarginAdjustedTolerance(testCase)
+            [~, ~, gamutMargin] = OLCheckPrimaryGamut([0-1e-4, 1+1e-4],'primaryTolerance',1e-3);
+            verifyEqual(testCase,gamutMargin,0,'AbsTol',1e-6);
+        end
+        
+        % Test argument primaryHeadroom
+        function adjustedPrimaryHeadroom(testCase)
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(.02));
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(.98));
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut([.02 .98]));
+            verifyError(testCase, @() OLCheckPrimaryGamut(.02,'primaryHeadroom',.05),'');
+            verifyError(testCase, @() OLCheckPrimaryGamut(.98,'primaryHeadroom',.05),'');
+            verifyError(testCase, @() OLCheckPrimaryGamut([.6,.98],'primaryHeadroom',.05),'');
+        end
+        function gamutMarginAdjustedHeadroom(testCase)
+            [~, ~, gamutMargin] = OLCheckPrimaryGamut([.6, .94],'primaryHeadroom',.05);
+            verifyEqual(testCase,gamutMargin,-.01,'AbsTol',1e-6);
+        end
+        
+        % Test argument checkPrimaryOutOfRange
+        function noErrorNoCheckOutOfRange(testCase)
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(1.1,'checkPrimaryOutOfRange',false))
+            verifyWarningFree(testCase, @() OLCheckPrimaryGamut(-.1,'checkPrimaryOutOfRange',false))
+        end
+        function truncateNoCheckOutOfRange(testCase)
+            primary = OLCheckPrimaryGamut([-1 1.1],'checkPrimaryOutOfRange',false);
+            verifyEqual(testCase,primary,[0 1])
+        end
+        function inGamutNoCheckOutOfRange(testCase)
+            [~,inGamut] = OLCheckPrimaryGamut([0 1.1],'checkPrimaryOutOfRange',false);
+            verifyFalse(testCase,inGamut);
+        end
+        function gamutMarginNoCheckOutOfRange(testCase)
+            [~, ~, gamutMargin] = OLCheckPrimaryGamut([-.1, 1.2],'checkPrimaryOutOfRange',false);
+            verifyEqual(testCase,gamutMargin,0.2,'AbsTol',1e-6);
+        end
+        
+    end
+end

--- a/xTests/testOLCheckPrimaryValues.m
+++ b/xTests/testOLCheckPrimaryValues.m
@@ -1,0 +1,33 @@
+classdef testOLCheckPrimaryValues < matlab.unittest.TestCase
+%TESTOLCHECKPRIMARYVALUES Summary of this class goes here
+%   Detailed explanation goes here
+
+% History:
+%    04/12/18  dhb  wrote OLCheckPrimaryGamut.
+%    12/19/18  jv   extracted OLCheckPrimaryValues from
+%                   OLCheckPrimaryGamut, and wrote tests
+
+    methods (Test)
+        % Test basic check
+        function outOfDefaultGamut(testCase)
+            verifyFalse(testCase,OLCheckPrimaryValues(1.1,[0 1]));
+            verifyFalse(testCase,OLCheckPrimaryValues(-.1,[0 1]));
+        end
+        function inDefaultGamut(testCase)
+            verifyTrue(testCase,OLCheckPrimaryValues(.8,[0 1]));
+        end
+        function inDifferentialGamut(testCase)
+            verifyTrue(testCase,OLCheckPrimaryValues(-.4,[-1 1]));
+            verifyFalse(testCase,OLCheckPrimaryValues(-.4,[0 1]));
+        end
+        function outOfDifferentialGamut(testCase)
+            verifyFalse(testCase,OLCheckPrimaryValues(-1.4,[-1 1]));
+        end
+        function inCustomGamut(testCase)
+            verifyTrue(testCase,OLCheckPrimaryValues(.6,[.2 .8]));
+        end
+        function outOfCustomGamut(testCase)
+            verifyFalse(testCase,OLCheckPrimaryValues(.9,[.2 .8]));
+        end
+    end
+end

--- a/xTests/testOLGamutMargins.m
+++ b/xTests/testOLGamutMargins.m
@@ -1,0 +1,38 @@
+classdef testOLGamutMargins < matlab.unittest.TestCase
+%TESTOLCHECKPRIMARYVALUES Summary of this class goes here
+%   Detailed explanation goes here
+
+% History:
+%    04/12/18  dhb  wrote OLCheckPrimaryGamut.
+%    12/19/18  jv   extracted OLPrimaryGamut from
+%                   OLCheckPrimaryGamut, and wrote tests
+
+    methods (Test)
+        function gamutMarginInDefaultGamut(testCase)
+            gamutMargins = OLGamutMargins([0.1, .8],[0 1]);
+            verifyEqual(testCase,gamutMargins,[0.1, .2],'AbsTol',1e-6);
+        end
+        function gamutMarginOutOfDefaultGamut(testCase)
+            gamutMargins = OLGamutMargins([-0.1, 1.8],[0 1]);
+            verifyEqual(testCase,gamutMargins,[-0.1, -.8],'AbsTol',1e-6);
+        end
+        
+        function gamutMarginInDifferentialGamut(testCase)
+            gamutMargins = OLGamutMargins([-0.1, .8],[-1 1]);
+            verifyEqual(testCase,gamutMargins,[0.9, .2],'AbsTol',1e-6);
+        end
+        function gamutMarginOutOfDifferentialGamut(testCase)
+            gamutMargins = OLGamutMargins([-1.1, 1.8],[-1 1]);
+            verifyEqual(testCase,gamutMargins,[-0.1, -.8],'AbsTol',1e-6);
+        end
+        
+        function gamutMarginInCustomGamut(testCase)
+            gamutMargins = OLGamutMargins([-0.1, .8],[-.8 .8]);
+            verifyEqual(testCase,gamutMargins,[0.7, 0],'AbsTol',1e-6);
+        end
+        function gamutMarginOutOfCustomGamut(testCase)
+            gamutMargins = OLGamutMargins([-1.1, 1.8],[-.8 .8]);
+            verifyEqual(testCase,gamutMargins,[-.3, -1],'AbsTol',1e-6);
+        end
+    end
+end

--- a/xTests/testOLTruncateGamutTolerance.m
+++ b/xTests/testOLTruncateGamutTolerance.m
@@ -1,0 +1,84 @@
+classdef testOLTruncateGamutTolerance < matlab.unittest.TestCase
+    %TESTOLTRUNCATEGAMUTTOLERANCE Summary of this class goes here
+    %   Detailed explanation goes here
+    
+    methods (Test)
+    	function truncateToStandardGamutTop(testCase)
+            % Truncate value smaller than tolerance; truncates to gamut
+            primaryValues = 1+1e-6;
+            primaryTolerance = 1e-5;
+            gamut = [0 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, 1, 'AbsTol',1e-5);
+        end
+        function truncateToStandardGamutBottom(testCase)
+            % Truncate value smaller than tolerance; truncates to gamut
+            primaryValues = 0-1e-6;
+            primaryTolerance = 1e-5;
+            gamut = [0 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, 0, 'AbsTol', 1e-5);
+        end
+        function trunacteToDifferentialGamutBottom(testCase)
+            % Truncate value smaller than tolerance; truncates to gamut
+            primaryValues = -1-1e-6;
+            primaryTolerance = 1e-5;
+            gamut = [-1 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, -1, 'AbsTol', 1e-5);
+        end
+        function truncateAboveStandardGamutTop(testCase)
+            % Truncate value larger than tolerance; truncates by tolerance
+            primaryValues = 1+1e-4;
+            primaryTolerance = 1e-5;
+            gamut = [0 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, 1+(1e-4)-(1e-5), 'AbsTol', 1e-5);
+        end
+        function truncateBelowStandardGamutBottom(testCase)
+            % Truncate value larger than tolerance; truncates by tolerance
+            primaryValues = 0-1e-4;
+            primaryTolerance = 1e-5;
+            gamut = [0 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, 0-(1e-4)+(1e-5), 'AbsTol', 1e-5);
+        end
+        function truncateWithinGamut(testCase)
+            % Primary value initially in gamut remains unaffected
+            primaryValues = .5;
+            primaryTolerance = 1e-5;
+            gamut = [0 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, primaryValues, 'AbsTol', 1e-5)
+        end
+        function truncateAll(testCase)
+            % Truncate both top and bottom, in and out of gamut:
+            primaryValues = [.9 1.04 1.1 .1 -.04 -.1];
+            primaryTolerance = .05;
+            gamut = [0 1];
+
+            truncatedPrimaryValues = OLTruncateGamutTolerance(primaryValues,...
+            gamut, primaryTolerance);
+
+            verifyEqual(testCase, truncatedPrimaryValues, [.9 1 1.05 .1 0 -.05], 'AbsTol', 1e-5);
+        end
+    end
+end

--- a/xTests/testOLTruncatePrimaryValues.m
+++ b/xTests/testOLTruncatePrimaryValues.m
@@ -1,0 +1,61 @@
+classdef testOLTruncatePrimaryValues < matlab.unittest.TestCase
+    %TESTOLTRUNCATEPRIMARYVALUES Summary of this class goes here
+    %   Detailed explanation goes here
+    
+    methods (Test)
+        function standardMin(testCase)
+            % Truncate to gamut-max
+            primaryValues = 2;
+            gamut = [0 1];
+            truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+            
+            % Check
+            verifyEqual(testCase, truncatedPrimaryValues, 1, 'AbsTol', 1e-5);
+        end
+        function standardMax(testCase)
+            % Truncate to gamut-min
+            primaryValues = -1;
+            gamut = [0 1];
+            truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+            
+            % Check
+            verifyEqual(testCase, truncatedPrimaryValues, 0, 'AbsTol', 1e-5);
+        end
+        function standardGamut(testCase)
+            % Truncate to gamut = [0 1]
+            primaryValues = [-.5 0 .4 .8 1 1.6];
+            gamut = [0 1];
+            truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+            
+            % Check
+            verifyEqual(testCase, truncatedPrimaryValues, [0 0 .4 .8 1 1], 'AbsTol', 1e-5);
+        end
+        function inGamut(testCase)
+            % Truncate to gamut = [-1 1]
+            primaryValues = [-1 1];
+            gamut = [-1 1];
+            truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+            
+            % Check
+            verifyEqual(testCase, truncatedPrimaryValues, primaryValues);
+        end
+        function unsortedGamut(testCase)
+            % Gamut is auto-sorted
+            primaryValues = [-1 -1];
+            gamut = [0 -1];
+            truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+            
+            % Check
+            verifyEqual(testCase, truncatedPrimaryValues, primaryValues);
+        end
+        function headroom(testCase)
+            % Leave some 'headroom' on primaries:
+            primaryValues = [0 .8 1];
+            gamut = [0.005 .995];
+            truncatedPrimaryValues = OLTruncatePrimaryValues(primaryValues, gamut);
+            
+            % Check
+            verifyEqual(testCase, truncatedPrimaryValues, [.005 .8 .995], 'AbsTol', 1e-5);
+        end
+    end
+end


### PR DESCRIPTION
`OLCheckPrimaryGamut` was performing double/triple duty by checking gamut, applying headroom, dealing with tolerances and occasionally truncating, with various flags and keyword arguments.

In this branch, I have separated these functions as follows:
`OLCheckPrimaryValues` returns a boolean whether primary values are within the given gamut.
`OLGamutMargins` returns a vector of the remaining room the given primary values have at bottom and top of the gamut. If primary values are outside gamut, these values are negative.
`OLTruncatePrimaryValues` does as it says, and truncates the given primary values to be within the given gamut (and fully within that, no hassling with tolerances here).
`OLTruncateGamutTolerance` truncates any primary values outside the gamut towards the gamut edge, but won't truncate them by anything more than the given tolerance value.
Unit tests are present for all of these functions.

`OLCheckPrimaryGamut` has integrated these functions, but still behaves exactly as it did before. A UnitTest class `testOLCheckPrimaryGamut` can be used to ensure this, see first commit on this PR. 